### PR TITLE
Replace componentWillUpdate

### DIFF
--- a/src/components/HOC/Loading.js
+++ b/src/components/HOC/Loading.js
@@ -13,7 +13,7 @@ const Loading = loadingProp => WrappedComponent => {
       this.startTimer = Date.now();
     }
 
-    componentWillUpdate(nextProps) {
+    componentDidUpdate(nextProps) {
       if (!isEmpty(nextProps[loadingProp])) {
         this.endTimer = Date.now();
       }


### PR DESCRIPTION
Replaced componentWillUpdate with componentDidUpdate as componentWillUpdate is unsafe to use and will not work in future versions of react